### PR TITLE
Fix DRLParser.g4 to Enforce Correct Order of packagedef and unitdef

### DIFF
--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -32,7 +32,7 @@ import DRL6Expressions, JavaParser;
      *           |  query
      *           ;
      */
-compilationUnit : packagedef? unitdef? drlStatementdef* EOF ;
+compilationUnit : (packagedef unitdef?)? drlStatementdef* EOF ;
 
 drlStatementdef
     : importdef SEMI?


### PR DESCRIPTION
This PR fixes an issue where unitdef could appear independently in the compilationUnit rule. The change ensures that unitdef can only be present if packagedef is specified, maintaining correct DRL syntax.

What I Did to Fix the Issue:
Modified the compilationUnit rule in DRLParser.g4:
Before:
compilationUnit : packagedef? unitdef? drlStatementdef* EOF ;
After:
compilationUnit : (packagedef unitdef?)? drlStatementdef* EOF ;
This update makes unitdef dependent on packagedef, preventing incorrect standalone usage.
Why This Fix is Needed:
The old rule allowed unitdef to appear without packagedef, which is not valid in DRL.
Ensures consistency with the expected DRL structure and aligns with how the old parser behaved.

